### PR TITLE
 * Mysql warning and dump Error fixed

### DIFF
--- a/mysqlblasy.pl
+++ b/mysqlblasy.pl
@@ -533,7 +533,7 @@ sub ldb_databases
 		}
 	}
 	push( @cmd, '--silent' );
-	push( @cmd, '--exec', 'SHOW DATABASES' );
+	push( @cmd, '-e', 'SHOW DATABASES' );
 	logDebug(@cmd);
 
 	my $output        = '';


### PR DESCRIPTION
- Warning: Using unique option prefix exec instead of execute is deprecated and will be removed in a future release. Please use the full name instead.
- use -e 'SHOW DATABASES' instead of --exec 'SHOW DATABASES'
